### PR TITLE
change PHP to use Apache

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
       context: ./php/
       dockerfile: Dockerfile
     ports:
-      - 8003:8003
+      - 8003:80
 
   deno:
     build:

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,10 +1,8 @@
-FROM php:8.2
+FROM php:8.2-apache
 
 WORKDIR /var/www/html
 
-COPY benchmark.php .
-COPY server.php .
+COPY benchmark.php /var/www/html/benchmark.php
+COPY server.php /var/www/html/index.php
 
 EXPOSE 8003
-
-CMD ["php", "-S", "0.0.0.0:8003", "server.php"]


### PR DESCRIPTION
this should be a more real-world test case scenario since PHP is usually used with Apache or other web servers. The embedded PHP server is not for production usage hence PHP looks less performant for this reason.